### PR TITLE
Add comprehensive end-to-end tests for blogs and posts

### DIFF
--- a/__tests__/blogs.e2e.test.ts
+++ b/__tests__/blogs.e2e.test.ts
@@ -1,0 +1,127 @@
+import request from "supertest";
+import express from "express";
+import { setupApp } from "../src/setup-app";
+import { HttpStatus } from "../src/core/types/http-statuses";
+
+const app = setupApp(express());
+const authHeader = "Basic " + Buffer.from("admin:qwerty").toString("base64");
+const nonExistingId = "123456789012345678901234";
+
+describe("/blogs", () => {
+  beforeEach(async () => {
+    await request(app).delete("/testing/all-data");
+  });
+
+  it("should return an empty array", async () => {
+    const res = await request(app).get("/blogs").expect(HttpStatus.Ok);
+    expect(res.body).toEqual([]);
+  });
+
+  it("should return 404 for not existing blog", async () => {
+    await request(app)
+      .get(`/blogs/${nonExistingId}`)
+      .expect(HttpStatus.NotFound);
+  });
+
+  it("should not create blog without auth", async () => {
+    await request(app)
+      .post("/blogs")
+      .send({
+        name: "Test",
+        description: "Desc",
+        websiteUrl: "https://example.com",
+      })
+      .expect(HttpStatus.Unauthorized);
+  });
+
+  it("should not create blog with invalid data", async () => {
+    await request(app)
+      .post("/blogs")
+      .set("Authorization", authHeader)
+      .send({
+        name: "",
+        description: "Desc",
+        websiteUrl: "https://example.com",
+      })
+      .expect(HttpStatus.BadRequest);
+  });
+
+  it("should create and get blog", async () => {
+    const createRes = await request(app)
+      .post("/blogs")
+      .set("Authorization", authHeader)
+      .send({
+        name: "MyBlog",
+        description: "Blog description",
+        websiteUrl: "https://example.com",
+      })
+      .expect(HttpStatus.Created);
+
+    expect(createRes.body).toEqual({
+      id: expect.any(String),
+      name: "MyBlog",
+      description: "Blog description",
+      websiteUrl: "https://example.com",
+    });
+
+    const getRes = await request(app)
+      .get(`/blogs/${createRes.body.id}`)
+      .expect(HttpStatus.Ok);
+
+    expect(getRes.body).toEqual(createRes.body);
+  });
+
+  it("should update blog", async () => {
+    const createRes = await request(app)
+      .post("/blogs")
+      .set("Authorization", authHeader)
+      .send({
+        name: "Old",
+        description: "Old desc",
+        websiteUrl: "https://example.com",
+      })
+      .expect(HttpStatus.Created);
+
+    await request(app)
+      .put(`/blogs/${createRes.body.id}`)
+      .set("Authorization", authHeader)
+      .send({
+        name: "New",
+        description: "New desc",
+        websiteUrl: "https://example.org",
+      })
+      .expect(HttpStatus.NoContent);
+
+    const getRes = await request(app)
+      .get(`/blogs/${createRes.body.id}`)
+      .expect(HttpStatus.Ok);
+
+    expect(getRes.body).toEqual({
+      id: createRes.body.id,
+      name: "New",
+      description: "New desc",
+      websiteUrl: "https://example.org",
+    });
+  });
+
+  it("should delete blog", async () => {
+    const createRes = await request(app)
+      .post("/blogs")
+      .set("Authorization", authHeader)
+      .send({
+        name: "ToDelete",
+        description: "Desc",
+        websiteUrl: "https://example.com",
+      })
+      .expect(HttpStatus.Created);
+
+    await request(app)
+      .delete(`/blogs/${createRes.body.id}`)
+      .set("Authorization", authHeader)
+      .expect(HttpStatus.NoContent);
+
+    await request(app)
+      .get(`/blogs/${createRes.body.id}`)
+      .expect(HttpStatus.NotFound);
+  });
+});

--- a/__tests__/posts.e2e.test.ts
+++ b/__tests__/posts.e2e.test.ts
@@ -1,0 +1,166 @@
+import request from "supertest";
+import express from "express";
+import { setupApp } from "../src/setup-app";
+import { HttpStatus } from "../src/core/types/http-statuses";
+
+const app = setupApp(express());
+const authHeader = "Basic " + Buffer.from("admin:qwerty").toString("base64");
+const nonExistingId = "123456789012345678901234";
+
+const createBlog = async () => {
+  const res = await request(app)
+    .post("/blogs")
+    .set("Authorization", authHeader)
+    .send({
+      name: "Blog",
+      description: "Desc",
+      websiteUrl: "https://example.com",
+    });
+  return res.body;
+};
+
+describe("/posts", () => {
+  beforeEach(async () => {
+    await request(app).delete("/testing/all-data");
+  });
+
+  it("should return an empty array", async () => {
+    const res = await request(app).get("/posts").expect(HttpStatus.Ok);
+    expect(res.body).toEqual([]);
+  });
+
+  it("should not create post without auth", async () => {
+    await request(app)
+      .post("/posts")
+      .send({
+        title: "T",
+        shortDescription: "S",
+        content: "C",
+        blogId: nonExistingId,
+      })
+      .expect(HttpStatus.Unauthorized);
+  });
+
+  it("should return 404 when blog not found", async () => {
+    await request(app)
+      .post("/posts")
+      .set("Authorization", authHeader)
+      .send({
+        title: "T",
+        shortDescription: "S",
+        content: "C",
+        blogId: nonExistingId,
+      })
+      .expect(HttpStatus.NotFound);
+  });
+
+  it("should not create post with invalid data", async () => {
+    const blog = await createBlog();
+    await request(app)
+      .post("/posts")
+      .set("Authorization", authHeader)
+      .send({
+        title: "",
+        shortDescription: "S",
+        content: "C",
+        blogId: blog.id,
+      })
+      .expect(HttpStatus.BadRequest);
+  });
+
+  it("should create and get post", async () => {
+    const blog = await createBlog();
+    const createRes = await request(app)
+      .post("/posts")
+      .set("Authorization", authHeader)
+      .send({
+        title: "Post",
+        shortDescription: "Short",
+        content: "Content",
+        blogId: blog.id,
+      })
+      .expect(HttpStatus.Created);
+
+    expect(createRes.body).toEqual({
+      id: expect.any(String),
+      title: "Post",
+      shortDescription: "Short",
+      content: "Content",
+      blogId: blog.id,
+      blogName: blog.name,
+    });
+
+    const getRes = await request(app)
+      .get(`/posts/${createRes.body.id}`)
+      .expect(HttpStatus.Ok);
+
+    expect(getRes.body).toEqual(createRes.body);
+  });
+
+  it("should update post", async () => {
+    const blog = await createBlog();
+    const postRes = await request(app)
+      .post("/posts")
+      .set("Authorization", authHeader)
+      .send({
+        title: "Post",
+        shortDescription: "Short",
+        content: "Content",
+        blogId: blog.id,
+      });
+    const newBlog = await request(app)
+      .post("/blogs")
+      .set("Authorization", authHeader)
+      .send({
+        name: "Another",
+        description: "Desc",
+        websiteUrl: "https://example.org",
+      });
+
+    await request(app)
+      .put(`/posts/${postRes.body.id}`)
+      .set("Authorization", authHeader)
+      .send({
+        title: "New",
+        shortDescription: "New short",
+        content: "New content",
+        blogId: newBlog.body.id,
+      })
+      .expect(HttpStatus.NoContent);
+
+    const getRes = await request(app)
+      .get(`/posts/${postRes.body.id}`)
+      .expect(HttpStatus.Ok);
+
+    expect(getRes.body).toEqual({
+      id: postRes.body.id,
+      title: "New",
+      shortDescription: "New short",
+      content: "New content",
+      blogId: newBlog.body.id,
+      blogName: newBlog.body.name,
+    });
+  });
+
+  it("should delete post", async () => {
+    const blog = await createBlog();
+    const postRes = await request(app)
+      .post("/posts")
+      .set("Authorization", authHeader)
+      .send({
+        title: "Post",
+        shortDescription: "Short",
+        content: "Content",
+        blogId: blog.id,
+      });
+
+    await request(app)
+      .delete(`/posts/${postRes.body.id}`)
+      .set("Authorization", authHeader)
+      .expect(HttpStatus.NoContent);
+
+    await request(app)
+      .get(`/posts/${postRes.body.id}`)
+      .expect(HttpStatus.NotFound);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+import parserTs from "@typescript-eslint/parser";
+import eslintPluginTs from "@typescript-eslint/eslint-plugin";
+
+export default [
+  {
+    files: ["**/*.{ts,js}"],
+    ignores: ["node_modules/**", "dist/**"],
+    languageOptions: {
+      parser: parserTs,
+    },
+    plugins: {
+      "@typescript-eslint": eslintPluginTs,
+    },
+    rules: {},
+  },
+];

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.e2e.test.ts", "**/?(*.)+(spec|test).ts"],
+};


### PR DESCRIPTION
## Summary
- add jest and ESLint configs to enable TypeScript test and linting
- create end-to-end tests covering blog and post CRUD workflows

## Testing
- `npm run lint`
- `npm run jest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b4ad9ad48321a90d124f321797a7