### PR TITLE
feat: add service layer for posts and blogs

### DIFF
--- a/src/blogs/application/blogs.service.ts
+++ b/src/blogs/application/blogs.service.ts
@@ -1,0 +1,44 @@
+import {Blog} from '../types/blog';
+import {BlogInputDto} from '../dto/blog.input-dto';
+import {BlogsRepository} from '../repositories/blogs.repository';
+
+export const BlogsService = {
+    async findAll(): Promise<Blog[]> {
+        return BlogsRepository.findAll();
+    },
+
+    async findById(id: string): Promise<Blog | null> {
+        return BlogsRepository.findById(id);
+    },
+
+    async create(data: BlogInputDto): Promise<Blog> {
+        return BlogsRepository.create({
+            name: data.name,
+            description: data.description,
+            websiteUrl: data.websiteUrl,
+        });
+    },
+
+    async update(id: string, data: BlogInputDto): Promise<boolean> {
+        const blog = await BlogsRepository.findById(id);
+        if (!blog) {
+            return false;
+        }
+        await BlogsRepository.update(id, {
+            name: data.name,
+            description: data.description,
+            websiteUrl: data.websiteUrl,
+        });
+        return true;
+    },
+
+    async delete(id: string): Promise<boolean> {
+        const blog = await BlogsRepository.findById(id);
+        if (!blog) {
+            return false;
+        }
+        await BlogsRepository.delete(id);
+        return true;
+    },
+};
+

--- a/src/blogs/routers/handlers/create-blog.handler.ts
+++ b/src/blogs/routers/handlers/create-blog.handler.ts
@@ -1,9 +1,8 @@
 import {Request, Response} from "express";
 import {BlogInputDto} from "../../dto/blog.input-dto";
-import {BlogsRepository} from "../../repositories/blogs.repository";
 import {Blog} from "../../types/blog";
 import {HttpStatus} from "../../../core/types/http-statuses";
-
+import {BlogsService} from "../../application/blogs.service";
 
 export async function createBlogHandler(req: Request<{}, {}, BlogInputDto>, res: Response) {
     const newBlogData = {
@@ -11,6 +10,6 @@ export async function createBlogHandler(req: Request<{}, {}, BlogInputDto>, res:
         description: req.body.description,
         websiteUrl: req.body.websiteUrl,
     };
-    const newBlog: Blog = await BlogsRepository.create(newBlogData);
+    const newBlog: Blog = await BlogsService.create(newBlogData);
     return res.status(HttpStatus.Created).send(newBlog);
 }

--- a/src/blogs/routers/handlers/delete-blog.handler.ts
+++ b/src/blogs/routers/handlers/delete-blog.handler.ts
@@ -1,16 +1,15 @@
 import {Request, Response} from "express";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
-import {BlogsRepository} from "../../repositories/blogs.repository";
+import {BlogsService} from "../../application/blogs.service";
 
 export async function deleteBlogHandler(req: Request, res: Response) {
     const id = String(req.params.id);
-    const blog = await BlogsRepository.findById(id);
-    if (!blog) {
+    const isDeleted = await BlogsService.delete(id);
+    if (!isDeleted) {
         return res
             .status(HttpStatus.NotFound)
             .send(createErrorMessages([{field: 'id', message: 'Blog not found'}]));
     }
-    await BlogsRepository.delete(id);
     return res.sendStatus(HttpStatus.NoContent);
 }

--- a/src/blogs/routers/handlers/get-blog-list.handler.ts
+++ b/src/blogs/routers/handlers/get-blog-list.handler.ts
@@ -1,8 +1,8 @@
 import {Request, Response} from "express";
-import {BlogsRepository} from "../../repositories/blogs.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
+import {BlogsService} from "../../application/blogs.service";
 
 export async function getBlogListHandler(req: Request, res: Response) {
-    const blogs = await BlogsRepository.findAll();
+    const blogs = await BlogsService.findAll();
     return res.status(HttpStatus.Ok).send(blogs);
 }

--- a/src/blogs/routers/handlers/get-blog.handler.ts
+++ b/src/blogs/routers/handlers/get-blog.handler.ts
@@ -1,13 +1,11 @@
 import {Request, Response} from "express";
-import {BlogsRepository} from "../../repositories/blogs.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
-
+import {BlogsService} from "../../application/blogs.service";
 
 export async function getBlogHandler(req: Request, res: Response) {
     const id = String(req.params.id);
-    const blog = await BlogsRepository.findById(id);
-
+    const blog = await BlogsService.findById(id);
     if (!blog) {
         return res
             .status(HttpStatus.NotFound)

--- a/src/blogs/routers/handlers/update-blog.handler.ts
+++ b/src/blogs/routers/handlers/update-blog.handler.ts
@@ -1,24 +1,17 @@
 import {Request, Response} from "express";
 import {BlogInputDto} from "../../dto/blog.input-dto";
-import {Blog} from "../../types/blog";
-import {BlogsRepository} from "../../repositories/blogs.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
-
+import {BlogsService} from "../../application/blogs.service";
 
 export async function updateBlogHandler(req: Request<{ id: string }, {}, BlogInputDto>, res: Response) {
     const id = String(req.params.id);
-
-    const blog: Blog | null = await BlogsRepository.findById(id);
-
-    if (!blog) {
+    const isUpdated = await BlogsService.update(id, req.body);
+    if (!isUpdated) {
         return res.status(HttpStatus.NotFound)
             .send(
                 createErrorMessages([{ field: 'id', message: 'Blog not found' }]),
             );
     }
-
-    await BlogsRepository.update(id, req.body);
-
     return res.sendStatus(HttpStatus.NoContent);
 }

--- a/src/posts/application/posts.service.ts
+++ b/src/posts/application/posts.service.ts
@@ -1,0 +1,60 @@
+import {Post} from '../types/post';
+import {PostInputDto} from '../dto/post.input-dto';
+import {PostsRepository} from '../repositories/posts.repository';
+import {BlogsRepository} from '../../blogs/repositories/blogs.repository';
+
+export const PostsService = {
+    async findAll(): Promise<Post[]> {
+        return PostsRepository.findAll();
+    },
+
+    async findById(id: string): Promise<Post | null> {
+        return PostsRepository.findById(id);
+    },
+
+    async create(data: PostInputDto): Promise<Post | null> {
+        const blog = await BlogsRepository.findById(data.blogId);
+        if (!blog) {
+            return null;
+        }
+        return PostsRepository.create({
+            title: data.title,
+            shortDescription: data.shortDescription,
+            content: data.content,
+            blogId: data.blogId,
+            blogName: blog.name,
+        });
+    },
+
+    async update(
+        id: string,
+        data: PostInputDto,
+    ): Promise<'postNotFound' | 'blogNotFound' | 'success'> {
+        const post = await PostsRepository.findById(id);
+        if (!post) {
+            return 'postNotFound';
+        }
+        const blog = await BlogsRepository.findById(data.blogId);
+        if (!blog) {
+            return 'blogNotFound';
+        }
+        await PostsRepository.update(id, {
+            title: data.title,
+            shortDescription: data.shortDescription,
+            content: data.content,
+            blogId: data.blogId,
+            blogName: blog.name,
+        });
+        return 'success';
+    },
+
+    async delete(id: string): Promise<boolean> {
+        const post = await PostsRepository.findById(id);
+        if (!post) {
+            return false;
+        }
+        await PostsRepository.delete(id);
+        return true;
+    },
+};
+

--- a/src/posts/routers/handlers/create-post.handler.ts
+++ b/src/posts/routers/handlers/create-post.handler.ts
@@ -1,27 +1,17 @@
 import { Request, Response } from 'express';
 import {PostInputDto} from "../../dto/post.input-dto";
 import {Post} from "../../types/post";
-import {PostsRepository} from "../../repositories/posts.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
-import {BlogsRepository} from "../../../blogs/repositories/blogs.repository";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
-
+import {PostsService} from "../../application/posts.service";
 
 export async function createPostHandler(req: Request<{}, {}, PostInputDto>, res: Response) {
-    const blog  = await BlogsRepository.findById(req.body.blogId);
-    if (!blog) {
-            return res.status(HttpStatus.NotFound)
+    const newPost: Post | null = await PostsService.create(req.body);
+    if (!newPost) {
+        return res.status(HttpStatus.NotFound)
             .send(
                 createErrorMessages([{ field: 'blogId', message: 'Blog not found' }]),
             );
     }
-    const newPostData = {
-        title: req.body.title,
-        shortDescription: req.body.shortDescription,
-        content: req.body.content,
-        blogId: req.body.blogId,
-        blogName: blog.name
-    };
-    const newPost: Post = await PostsRepository.create(newPostData);
     return res.status(HttpStatus.Created).send(newPost);
 }

--- a/src/posts/routers/handlers/delete-post.handler.ts
+++ b/src/posts/routers/handlers/delete-post.handler.ts
@@ -1,16 +1,15 @@
 import {Request, Response} from "express";
-import {PostsRepository} from "../../repositories/posts.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
+import {PostsService} from "../../application/posts.service";
 
 export async function deletePostHandler(req: Request, res: Response) {
     const id = String(req.params.id);
-    const post = await PostsRepository.findById(id);
-    if (!post) {
+    const isDeleted = await PostsService.delete(id);
+    if (!isDeleted) {
         return res
             .status(HttpStatus.NotFound)
             .send(createErrorMessages([{field: 'id', message: 'Post not found'}]));
     }
-    await PostsRepository.delete(id);
     return res.sendStatus(HttpStatus.NoContent);
 }

--- a/src/posts/routers/handlers/get-post-list.handler.ts
+++ b/src/posts/routers/handlers/get-post-list.handler.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express';
-import {PostsRepository} from "../../repositories/posts.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
+import {PostsService} from "../../application/posts.service";
 
 export async function getPostListHandler(req: Request, res: Response) {
-    const posts = await PostsRepository.findAll();
+    const posts = await PostsService.findAll();
     return res.status(HttpStatus.Ok).send(posts);
 }

--- a/src/posts/routers/handlers/get-post.handler.ts
+++ b/src/posts/routers/handlers/get-post.handler.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express';
-import {PostsRepository} from "../../repositories/posts.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
+import {PostsService} from "../../application/posts.service";
 
 export async function getPostHandler(req: Request, res: Response) {
     const id = String(req.params.id);
-    const post = await PostsRepository.findById(id);
+    const post = await PostsService.findById(id);
     if (!post) {
         return res
             .status(HttpStatus.NotFound)

--- a/src/posts/routers/handlers/update-post.handler.ts
+++ b/src/posts/routers/handlers/update-post.handler.ts
@@ -1,29 +1,24 @@
 import {Request, Response} from "express";
 import {PostInputDto} from "../../dto/post.input-dto";
-import {PostsRepository} from "../../repositories/posts.repository";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {createErrorMessages} from "../../../core/middlewares/validation/input-validation-result.middleware";
-import {BlogsRepository} from "../../../blogs/repositories/blogs.repository";
+import {PostsService} from "../../application/posts.service";
 
 export async function updatePostHandler(req: Request<{ id: string }, {}, PostInputDto>, res: Response) {
     const id = String(req.params.id);
-    const post = await PostsRepository.findById(id);
-    if (!post) {
-        res
+    const result = await PostsService.update(id, req.body);
+    if (result === 'postNotFound') {
+        return res
             .status(HttpStatus.NotFound)
             .send(
                 createErrorMessages([{ field: 'id', message: 'Post not found' }]),
             );
-        return;
     }
-    const blog  = await BlogsRepository.findById(req.body.blogId);
-    if (!blog) {
+    if (result === 'blogNotFound') {
         return res.status(HttpStatus.NotFound)
             .send(
                 createErrorMessages([{ field: 'blogId', message: 'Blog not found' }]),
             );
     }
-    await PostsRepository.update(id, {...req.body, blogName: blog.name });
-
     return res.sendStatus(HttpStatus.NoContent);
 }


### PR DESCRIPTION
## Summary
- add PostsService to handle post operations and blog validation
- add BlogsService and update handlers to delegate business logic

## Testing
- `npm run lint`
- `MONGO_URL='mongodb://localhost:27017' npm run jest` *(fails: Exceeded timeout for hook)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be3ae8108321a08fe3b68585bef8