### PR TITLE
Implement pagination and search for blogs and posts

### DIFF
--- a/src/blogs/application/blogs.service.ts
+++ b/src/blogs/application/blogs.service.ts
@@ -1,10 +1,14 @@
 import {Blog} from '../domain/blog';
 import {BlogInputDto} from '../dto/blog.input-dto';
 import {BlogsRepository} from '../repositories/blogs.repository';
+import {BlogsQuery} from '../dto/blog.query';
+import {buildPaginator} from '../../core/utils/paginator';
+import {Paginator} from '../../core/types/pagination';
 
 export const BlogsService = {
-    async findAll(): Promise<Blog[]> {
-        return BlogsRepository.findAll();
+    async findAll(query: BlogsQuery): Promise<Paginator<Blog>> {
+        const {items, totalCount} = await BlogsRepository.findAll(query);
+        return buildPaginator(items, totalCount, query.pageNumber, query.pageSize);
     },
 
     async findById(id: string): Promise<Blog | null> {

--- a/src/blogs/dto/blog.query.ts
+++ b/src/blogs/dto/blog.query.ts
@@ -1,0 +1,5 @@
+import {PaginationQuery} from '../../core/types/pagination';
+
+export type BlogsQuery = PaginationQuery<string> & {
+    searchNameTerm?: string;
+};

--- a/src/blogs/routers/handlers/get-blog-list.handler.ts
+++ b/src/blogs/routers/handlers/get-blog-list.handler.ts
@@ -1,8 +1,26 @@
 import {Request, Response} from "express";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {BlogsService} from "../../application/blogs.service";
+import {parsePaginationQuery, getSearchTerm} from "../../../core/utils/query";
 
-export async function getBlogListHandler(req: Request, res: Response) {
-    const blogs = await BlogsService.findAll();
+type BlogListQuery = {
+    searchNameTerm?: string | string[];
+    pageNumber?: string | string[];
+    pageSize?: string | string[];
+    sortBy?: string | string[];
+    sortDirection?: string | string[];
+};
+
+export async function getBlogListHandler(
+    req: Request<{}, {}, {}, BlogListQuery>,
+    res: Response,
+) {
+    const paginationQuery = parsePaginationQuery(req.query, {defaultSortBy: 'createdAt'});
+    const searchNameTerm = getSearchTerm(req.query.searchNameTerm);
+
+    const blogs = await BlogsService.findAll({
+        ...paginationQuery,
+        searchNameTerm,
+    });
     return res.status(HttpStatus.Ok).send(blogs);
 }

--- a/src/blogs/routers/handlers/get-blog-posts.handler.ts
+++ b/src/blogs/routers/handlers/get-blog-posts.handler.ts
@@ -2,9 +2,17 @@ import {Request, Response} from "express";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {BlogsRepository} from "../../repositories/blogs.repository";
 import {PostsService} from "../../../posts/application/posts.service";
+import {parsePaginationQuery} from "../../../core/utils/query";
+
+type BlogPostsQuery = {
+    pageNumber?: string | string[];
+    pageSize?: string | string[];
+    sortBy?: string | string[];
+    sortDirection?: string | string[];
+};
 
 export async function getBlogPostsHandler(
-    req: Request<{id: string}>,
+    req: Request<{id: string}, {}, {}, BlogPostsQuery>,
     res: Response,
 ) {
     const blog = await BlogsRepository.findById(req.params.id);
@@ -12,6 +20,7 @@ export async function getBlogPostsHandler(
         return res.sendStatus(HttpStatus.NotFound);
     }
 
-    const posts = await PostsService.findAllByBlogId(req.params.id);
+    const paginationQuery = parsePaginationQuery(req.query, {defaultSortBy: 'createdAt'});
+    const posts = await PostsService.findAllByBlogId(req.params.id, paginationQuery);
     return res.status(HttpStatus.Ok).send(posts);
 }

--- a/src/core/types/pagination.ts
+++ b/src/core/types/pagination.ts
@@ -1,0 +1,16 @@
+export type SortDirection = 'asc' | 'desc';
+
+export type PaginationQuery<TSortBy extends string = string> = {
+    pageNumber: number;
+    pageSize: number;
+    sortBy: TSortBy;
+    sortDirection: SortDirection;
+};
+
+export type Paginator<T> = {
+    pagesCount: number;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    items: T[];
+};

--- a/src/core/utils/paginator.ts
+++ b/src/core/utils/paginator.ts
@@ -1,0 +1,17 @@
+import {Paginator} from '../types/pagination';
+
+export function buildPaginator<T>(
+    items: T[],
+    totalCount: number,
+    pageNumber: number,
+    pageSize: number,
+): Paginator<T> {
+    const pagesCount = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 0;
+    return {
+        pagesCount,
+        page: pageNumber,
+        pageSize,
+        totalCount,
+        items,
+    };
+}

--- a/src/core/utils/query.ts
+++ b/src/core/utils/query.ts
@@ -1,0 +1,85 @@
+import {PaginationQuery, SortDirection} from '../types/pagination';
+
+type QueryValue = string | string[] | undefined | null;
+
+type QueryRecord = Partial<Record<string, QueryValue>>;
+
+function getStringFromValue(value: QueryValue): string | undefined {
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (Array.isArray(value) && value.length > 0) {
+        const first = value[0];
+        return typeof first === 'string' ? first : undefined;
+    }
+    return undefined;
+}
+
+function parseNumber(value: QueryValue, defaultValue: number, minValue: number): number {
+    const str = getStringFromValue(value);
+    if (!str) {
+        return defaultValue;
+    }
+    const num = Number(str);
+    if (!Number.isFinite(num)) {
+        return defaultValue;
+    }
+    const integer = Math.floor(num);
+    if (integer < minValue) {
+        return defaultValue;
+    }
+    return integer;
+}
+
+function parseSortDirection(value: QueryValue, defaultValue: SortDirection): SortDirection {
+    const str = getStringFromValue(value)?.toLowerCase();
+    if (str === 'asc' || str === 'desc') {
+        return str;
+    }
+    return defaultValue;
+}
+
+function parseSortBy(value: QueryValue, defaultValue: string): string {
+    const str = getStringFromValue(value);
+    if (!str) {
+        return defaultValue;
+    }
+    const trimmed = str.trim();
+    return trimmed.length > 0 ? trimmed : defaultValue;
+}
+
+export function parsePaginationQuery(
+    query: QueryRecord,
+    options?: {
+        defaultPageNumber?: number;
+        defaultPageSize?: number;
+        defaultSortBy?: string;
+        defaultSortDirection?: SortDirection;
+    },
+): PaginationQuery<string> {
+    const defaultPageNumber = options?.defaultPageNumber ?? 1;
+    const defaultPageSize = options?.defaultPageSize ?? 10;
+    const defaultSortBy = options?.defaultSortBy ?? 'createdAt';
+    const defaultSortDirection = options?.defaultSortDirection ?? 'desc';
+
+    const pageNumber = parseNumber(query.pageNumber, defaultPageNumber, 1);
+    const pageSize = parseNumber(query.pageSize, defaultPageSize, 1);
+    const sortBy = parseSortBy(query.sortBy, defaultSortBy);
+    const sortDirection = parseSortDirection(query.sortDirection, defaultSortDirection);
+
+    return {
+        pageNumber,
+        pageSize,
+        sortBy,
+        sortDirection,
+    };
+}
+
+export function getSearchTerm(value: QueryValue): string | undefined {
+    const str = getStringFromValue(value);
+    if (!str) {
+        return undefined;
+    }
+    const trimmed = str.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/src/db/mongo-db.ts
+++ b/src/db/mongo-db.ts
@@ -1,14 +1,8 @@
-import {MongoClient, Collection, ObjectId} from 'mongodb';
+import {MongoClient, ObjectId} from 'mongodb';
 import dotenv from 'dotenv';
 
 dotenv.config();
 
-const mongoUrl = process.env.MONGO_URL || '';
-if (!mongoUrl) {
-    throw new Error('MONGO_URL not found');
-}
-
-const client = new MongoClient(mongoUrl);
 const dbName = 'blogger-platform';
 
 export type BlogDb = {
@@ -30,10 +24,188 @@ export type PostDb = {
     createdAt: string;
 };
 
-export let blogsCollection: Collection<BlogDb>;
-export let postsCollection: Collection<PostDb>;
+type SortSpecification = Record<string, 1 | -1>;
+
+type CursorLike<T> = {
+    sort(sort: SortSpecification): CursorLike<T>;
+    skip(skip: number): CursorLike<T>;
+    limit(limit: number): CursorLike<T>;
+    toArray(): Promise<T[]>;
+};
+
+export type CollectionLike<T extends {_id: ObjectId}> = {
+    find(filter?: any): CursorLike<T>;
+    findOne(filter: any): Promise<T | null>;
+    insertOne(doc: T): Promise<{acknowledged: boolean}>;
+    updateOne(filter: any, update: any): Promise<{acknowledged: boolean; matchedCount: number}>;
+    deleteOne(filter: any): Promise<{acknowledged: boolean; deletedCount: number}>;
+    deleteMany(filter: any): Promise<{acknowledged: boolean; deletedCount: number}>;
+    countDocuments(filter?: any): Promise<number>;
+};
+
+class InMemoryCursor<T extends {_id: ObjectId}> implements CursorLike<T> {
+    private sortParams: Array<[string, 1 | -1]> = [];
+    private skipValue = 0;
+    private limitValue: number | undefined;
+
+    constructor(private readonly data: T[], private readonly filter: any) {}
+
+    sort(sort: SortSpecification): CursorLike<T> {
+        this.sortParams = Object.entries(sort) as Array<[string, 1 | -1]>;
+        return this;
+    }
+
+    skip(skip: number): CursorLike<T> {
+        this.skipValue = skip;
+        return this;
+    }
+
+    limit(limit: number): CursorLike<T> {
+        this.limitValue = limit;
+        return this;
+    }
+
+    async toArray(): Promise<T[]> {
+        let result = this.data.filter((doc) => matchesFilter(doc, this.filter));
+        if (this.sortParams.length > 0) {
+            result = [...result].sort((a, b) => compareDocuments(a, b, this.sortParams));
+        } else {
+            result = [...result];
+        }
+        if (this.skipValue > 0) {
+            result = result.slice(this.skipValue);
+        }
+        if (this.limitValue !== undefined) {
+            result = result.slice(0, this.limitValue);
+        }
+        return result;
+    }
+}
+
+class InMemoryCollection<T extends {_id: ObjectId}> implements CollectionLike<T> {
+    private data: T[] = [];
+
+    find(filter: any = {}): CursorLike<T> {
+        return new InMemoryCursor(this.data, filter);
+    }
+
+    async findOne(filter: any): Promise<T | null> {
+        return this.data.find((doc) => matchesFilter(doc, filter)) ?? null;
+    }
+
+    async insertOne(doc: T): Promise<{acknowledged: boolean}> {
+        this.data.push({...doc});
+        return {acknowledged: true};
+    }
+
+    async updateOne(filter: any, update: any): Promise<{acknowledged: boolean; matchedCount: number}> {
+        const item = this.data.find((doc) => matchesFilter(doc, filter));
+        if (!item) {
+            return {acknowledged: true, matchedCount: 0};
+        }
+        if (update && update.$set && typeof update.$set === 'object') {
+            Object.assign(item, update.$set);
+        }
+        return {acknowledged: true, matchedCount: 1};
+    }
+
+    async deleteOne(filter: any): Promise<{acknowledged: boolean; deletedCount: number}> {
+        const index = this.data.findIndex((doc) => matchesFilter(doc, filter));
+        if (index === -1) {
+            return {acknowledged: true, deletedCount: 0};
+        }
+        this.data.splice(index, 1);
+        return {acknowledged: true, deletedCount: 1};
+    }
+
+    async deleteMany(filter: any): Promise<{acknowledged: boolean; deletedCount: number}> {
+        const initialLength = this.data.length;
+        const normalizedFilter = filter ?? {};
+        this.data = this.data.filter((doc) => !matchesFilter(doc, normalizedFilter));
+        return {acknowledged: true, deletedCount: initialLength - this.data.length};
+    }
+
+    async countDocuments(filter: any = {}): Promise<number> {
+        return this.data.filter((doc) => matchesFilter(doc, filter)).length;
+    }
+}
+
+function matchesFilter<T extends {_id: ObjectId}>(doc: T, filter: any): boolean {
+    if (!filter || Object.keys(filter).length === 0) {
+        return true;
+    }
+    return Object.entries(filter).every(([key, value]) => matchCondition((doc as any)[key], value));
+}
+
+function matchCondition(docValue: any, condition: any): boolean {
+    if (condition && typeof condition === 'object' && '$regex' in condition) {
+        const pattern = String(condition.$regex);
+        const options = typeof condition.$options === 'string' ? condition.$options : '';
+        const regex = new RegExp(pattern, options);
+        return regex.test(String(docValue ?? ''));
+    }
+    if (condition instanceof ObjectId) {
+        return docValue instanceof ObjectId && docValue.equals(condition);
+    }
+    return docValue === condition;
+}
+
+function compareDocuments<T>(a: T, b: T, sortParams: Array<[string, 1 | -1]>): number {
+    for (const [field, direction] of sortParams) {
+        const aValue = normalizeValue((a as any)[field]);
+        const bValue = normalizeValue((b as any)[field]);
+        if (aValue === bValue) {
+            continue;
+        }
+        if (aValue < bValue) {
+            return direction === 1 ? -1 : 1;
+        }
+        return direction === 1 ? 1 : -1;
+    }
+    return 0;
+}
+
+function normalizeValue(value: unknown): string {
+    if (value instanceof ObjectId) {
+        return value.toString();
+    }
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    if (value === null || value === undefined) {
+        return '';
+    }
+    return String(value);
+}
+
+let client: MongoClient | null = null;
+let useInMemoryStorage = false;
+
+const mongoUrl = process.env.MONGO_URL;
+if (!mongoUrl) {
+    if (process.env.NODE_ENV === 'test') {
+        useInMemoryStorage = true;
+    } else {
+        throw new Error('MONGO_URL not found');
+    }
+} else {
+    client = new MongoClient(mongoUrl);
+}
+
+export let blogsCollection: CollectionLike<BlogDb>;
+export let postsCollection: CollectionLike<PostDb>;
 
 export async function runDb() {
+    if (useInMemoryStorage) {
+        blogsCollection = new InMemoryCollection<BlogDb>();
+        postsCollection = new InMemoryCollection<PostDb>();
+        return;
+    }
+
+    if (!client) {
+        throw new Error('Mongo client not initialized');
+    }
+
     await client.connect();
     const db = client.db(dbName);
     blogsCollection = db.collection<BlogDb>('blogs');
@@ -41,5 +213,13 @@ export async function runDb() {
 }
 
 export async function closeDb() {
-    await client.close();
+    if (useInMemoryStorage) {
+        blogsCollection = new InMemoryCollection<BlogDb>();
+        postsCollection = new InMemoryCollection<PostDb>();
+        return;
+    }
+
+    if (client) {
+        await client.close();
+    }
 }

--- a/src/posts/application/posts.service.ts
+++ b/src/posts/application/posts.service.ts
@@ -3,14 +3,19 @@ import {PostInputDto} from '../dto/post.input-dto';
 import {PostsRepository} from '../repositories/posts.repository';
 import {BlogsRepository} from '../../blogs/repositories/blogs.repository';
 import {PostForBlogInputDto} from "../dto/post-for-blog.input-dto";
+import {PostsQuery} from '../dto/post.query';
+import {buildPaginator} from '../../core/utils/paginator';
+import {Paginator} from '../../core/types/pagination';
 
 export const PostsService = {
-    async findAll(): Promise<Post[]> {
-        return PostsRepository.findAll();
+    async findAll(query: PostsQuery): Promise<Paginator<Post>> {
+        const {items, totalCount} = await PostsRepository.findAll(query);
+        return buildPaginator(items, totalCount, query.pageNumber, query.pageSize);
     },
 
-    async findAllByBlogId(blogId: string): Promise<Post[]> {
-        return PostsRepository.findAllByBlogId(blogId);
+    async findAllByBlogId(blogId: string, query: PostsQuery): Promise<Paginator<Post>> {
+        const {items, totalCount} = await PostsRepository.findAllByBlogId(blogId, query);
+        return buildPaginator(items, totalCount, query.pageNumber, query.pageSize);
     },
 
     async findById(id: string): Promise<Post | null> {

--- a/src/posts/dto/post.query.ts
+++ b/src/posts/dto/post.query.ts
@@ -1,0 +1,3 @@
+import {PaginationQuery} from '../../core/types/pagination';
+
+export type PostsQuery = PaginationQuery<string>;

--- a/src/posts/routers/handlers/get-post-list.handler.ts
+++ b/src/posts/routers/handlers/get-post-list.handler.ts
@@ -1,8 +1,20 @@
 import { Request, Response } from 'express';
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {PostsService} from "../../application/posts.service";
+import {parsePaginationQuery} from "../../../core/utils/query";
 
-export async function getPostListHandler(req: Request, res: Response) {
-    const posts = await PostsService.findAll();
+type PostListQuery = {
+    pageNumber?: string | string[];
+    pageSize?: string | string[];
+    sortBy?: string | string[];
+    sortDirection?: string | string[];
+};
+
+export async function getPostListHandler(
+    req: Request<{}, {}, {}, PostListQuery>,
+    res: Response,
+) {
+    const paginationQuery = parsePaginationQuery(req.query, {defaultSortBy: 'createdAt'});
+    const posts = await PostsService.findAll(paginationQuery);
     return res.status(HttpStatus.Ok).send(posts);
 }


### PR DESCRIPTION
## Summary
- add shared pagination types/utilities and apply them to blog and post services
- implement searchNameTerm filtering for blogs with paginated/sorted responses across list endpoints
- provide an in-memory Mongo fallback for tests and update e2e suites for the new paginator contract

## Testing
- pnpm jest

------
https://chatgpt.com/codex/tasks/task_e_68ceb4d308dc8321a1abb4cacf5e40c3