### PR TITLE
Allow sorting users by multiple fields

### DIFF
--- a/src/users/dto/user.query.ts
+++ b/src/users/dto/user.query.ts
@@ -1,6 +1,8 @@
 import {PaginationQuery} from "../../core/types/pagination";
 
-export type UsersQuery = PaginationQuery<'createdAt'> & {
+export type UserSortBy = 'createdAt' | 'login' | 'email';
+
+export type UsersQuery = PaginationQuery<UserSortBy> & {
     searchLoginTerm?: string;
     searchEmailTerm?: string;
 };

--- a/src/users/routers/handlers/get-user-list.handler.ts
+++ b/src/users/routers/handlers/get-user-list.handler.ts
@@ -2,7 +2,7 @@ import {Request, Response} from "express";
 import {HttpStatus} from "../../../core/types/http-statuses";
 import {parsePaginationQuery, getSearchTerm} from "../../../core/utils/query";
 import {UsersService} from "../../application/users.service";
-import {UsersQuery} from "../../dto/user.query";
+import {UsersQuery, UserSortBy} from "../../dto/user.query";
 
 type UserListQuery = {
     pageNumber?: string | string[];
@@ -21,13 +21,19 @@ export async function getUserListHandler(
     const searchLoginTerm = getSearchTerm(req.query.searchLoginTerm);
     const searchEmailTerm = getSearchTerm(req.query.searchEmailTerm);
 
+    const sortBy = isUserSortBy(paginationQuery.sortBy) ? paginationQuery.sortBy : 'createdAt';
+
     const usersQuery: UsersQuery = {
         ...paginationQuery,
-        sortBy: 'createdAt',
+        sortBy,
         searchLoginTerm,
         searchEmailTerm,
     };
 
     const users = await UsersService.findAll(usersQuery);
     return res.status(HttpStatus.Ok).send(users);
+}
+
+function isUserSortBy(sortBy: string): sortBy is UserSortBy {
+    return sortBy === 'createdAt' || sortBy === 'login' || sortBy === 'email';
 }


### PR DESCRIPTION
## Summary
- allow clients to request user listings sorted by login, email, or creation date
- ensure pagination query parsing defaults to createdAt but respects other allowed user fields

## Testing
- pnpm jest *(fails: timed out waiting for tests to finish)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d4ac2f30832185b3798f9cb092c4