### PR TITLE
Return JWT token after successful login

### DIFF
--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -1,13 +1,54 @@
+import {createHmac} from "crypto";
 import bcrypt from "bcrypt";
 import {UsersRepository} from "../../users/repositories/users.repository";
+import {UserAccount} from "../../users/domain/user";
+
+const JWT_SECRET = process.env.JWT_SECRET || "jwt-secret";
+const ACCESS_TOKEN_TTL_SECONDS = Number(process.env.JWT_ACCESS_TOKEN_TTL_SECONDS) || 60 * 10;
+
+const base64UrlEncode = (input: Buffer | string): string => {
+    return Buffer.from(input)
+        .toString("base64")
+        .replace(/=/g, "")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_");
+};
+
+const createToken = (payload: Record<string, unknown>, secret: string, ttlSeconds: number): string => {
+    const header = {alg: "HS256", typ: "JWT"};
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const body = {
+        ...payload,
+        iat: issuedAt,
+        exp: issuedAt + ttlSeconds,
+    };
+
+    const encodedHeader = base64UrlEncode(JSON.stringify(header));
+    const encodedPayload = base64UrlEncode(JSON.stringify(body));
+    const signature = createHmac("sha256", secret)
+        .update(`${encodedHeader}.${encodedPayload}`)
+        .digest();
+    const encodedSignature = base64UrlEncode(signature);
+
+    return `${encodedHeader}.${encodedPayload}.${encodedSignature}`;
+};
 
 export const AuthService = {
-    async verifyCredentials(loginOrEmail: string, password: string): Promise<boolean> {
+    async verifyCredentials(loginOrEmail: string, password: string): Promise<UserAccount | null> {
         const user = await UsersRepository.findAccountByLoginOrEmail(loginOrEmail);
         if (!user) {
-            return false;
+            return null;
         }
 
-        return bcrypt.compare(password, user.passwordHash);
+        const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+        if (!isPasswordValid) {
+            return null;
+        }
+
+        return user;
+    },
+
+    createAccessToken(userId: string): string {
+        return createToken({userId}, JWT_SECRET, ACCESS_TOKEN_TTL_SECONDS);
     },
 };

--- a/src/auth/routers/handlers/login.handler.ts
+++ b/src/auth/routers/handlers/login.handler.ts
@@ -7,14 +7,16 @@ export async function loginHandler(
     req: Request<{}, {}, LoginInputDto>,
     res: Response,
 ) {
-    const isValid = await AuthService.verifyCredentials(
+    const user = await AuthService.verifyCredentials(
         req.body.loginOrEmail,
         req.body.password,
     );
 
-    if (!isValid) {
+    if (!user) {
         return res.sendStatus(HttpStatus.Unauthorized);
     }
 
-    return res.sendStatus(HttpStatus.NoContent);
+    const accessToken = AuthService.createAccessToken(user.id);
+
+    return res.status(HttpStatus.Ok).json({accessToken});
 }


### PR DESCRIPTION
## Summary
- return the authenticated user from credential verification and generate signed JWT tokens
- respond to successful logins with an access token payload instead of a 204 status

## Testing
- pnpm jest

------
https://chatgpt.com/codex/tasks/task_e_68e223260e0c832186c4076b695b0bb5